### PR TITLE
Support Laravel 5.5 again, fixes #17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,4 +33,4 @@ script:
   - vendor/bin/phpunit --coverage-clover build/logs/clover.xml
 
 after_script:
-  - sh -c "if [ $TRAVIS_PHP_VERSION = '7.2' && ILLUMINATE_VERSION = '5.6.*' ]; then php ocular.phar code-coverage:upload --format=php-clover build/logs/clover.xml; fi"
+  - sh -c "if [[ $TRAVIS_PHP_VERSION = '7.2' && $ILLUMINATE_VERSION = '5.6.*' ]]; then php ocular.phar code-coverage:upload --format=php-clover build/logs/clover.xml; fi"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,33 @@ php:
   - 7.1
   - 7.2
 
-before_script:
+cache:
+  directories:
+    - $HOME/.composer/cache
+
+matrix:
+  include:
+    - php: 7.1
+      env: ILLUMINATE_VERSION=5.5.* PHPUNIT_VERSION=6.*
+    - php: 7.1
+      env: ILLUMINATE_VERSION=5.6.* PHPUNIT_VERSION=7.*
+    - php: 7.2
+      env: ILLUMINATE_VERSION=5.5.* PHPUNIT_VERSION=6.*
+    - php: 7.2
+      env: ILLUMINATE_VERSION=5.6.* PHPUNIT_VERSION=7.*
+
+before_install:
+  - if [ -n "$ILLUMINATE_VERSION" ] ; then composer require illuminate/support:${ILLUMINATE_VERSION} illuminate/console:${ILLUMINATE_VERSION} --no-update; fi
+  - if [ -n "$PHPUNIT_VERSION" ] ; then composer require phpunit/phpunit:${PHPUNIT_VERSION} --no-update; fi
+  - mkdir -p build/logs
+
+install:
   - composer self-update
   - composer install
   - wget https://scrutinizer-ci.com/ocular.phar
 
 script:
- - mkdir -p build/logs
- - vendor/bin/phpunit --coverage-clover build/logs/clover.xml
+  - vendor/bin/phpunit --coverage-clover build/logs/clover.xml
 
 after_script:
- - sh -c "if [ $TRAVIS_PHP_VERSION = '7.2' ]; then php ocular.phar code-coverage:upload --format=php-clover build/logs/clover.xml; fi"
+  - sh -c "if [ $TRAVIS_PHP_VERSION = '7.2' && ILLUMINATE_VERSION = '5.6.*' ]; then php ocular.phar code-coverage:upload --format=php-clover build/logs/clover.xml; fi"

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
   ],
   "require": {
     "php": "^7.1.3",
-    "illuminate/support": ">=5.6 <5.7",
-    "illuminate/console": ">=5.6 <5.7",
+    "illuminate/support": "5.5.*|5.6.*",
+    "illuminate/console": "5.5.*|5.6.*",
     "dragonmantank/cron-expression": "~2.0"
   },
   "require-dev": {

--- a/src/ScheduleList.php
+++ b/src/ScheduleList.php
@@ -107,12 +107,28 @@ class ScheduleList
      */
     private function getNextRunDate(Event $event): Carbon
     {
-        $cron = CronExpression::factory($event->getExpression());
+        $cron = CronExpression::factory($this->truncateCronExpression($event->getExpression()));
         $nextRun = Carbon::instance($cron->getNextRunDate());
         if ($event->timezone){
             $nextRun->setTimezone($event->timezone);
         }
 
         return $nextRun;
+    }
+
+    /**
+     * Truncate the cron-expression to allow for Laravel <=5.5 that uses 6 positions for the expression
+     *
+     * @param string $expression
+     * @return string
+     */
+    private function truncateCronExpression(string $expression): string
+    {
+        $expression = explode(' ', $expression);
+        if (count($expression) > 5) {
+            $expression = array_slice($expression, 0, 5);
+        }
+
+        return implode(' ', $expression);
     }
 }

--- a/src/ScheduleList.php
+++ b/src/ScheduleList.php
@@ -124,11 +124,12 @@ class ScheduleList
      */
     private function truncateCronExpression(string $expression): string
     {
-        $expression = explode(' ', $expression);
-        if (count($expression) > 5) {
-            $expression = array_slice($expression, 0, 5);
+        $expressionParts = preg_split('/\s/', $expression, -1, PREG_SPLIT_NO_EMPTY);
+        if (count($expressionParts) === 5) {
+            return $expression;
         }
 
-        return implode(' ', $expression);
+        $expressionParts = array_slice($expressionParts, 0, 5);
+        return implode(' ', $expressionParts);
     }
 }

--- a/tests/Integration/ListSchedulerTest.php
+++ b/tests/Integration/ListSchedulerTest.php
@@ -30,6 +30,8 @@ class ListSchedulerTest extends TestCase
         self::assertContains('Description of test command', $consoleOutput[4]);
 
         self::assertContains('ls -lah', $consoleOutput[5]);
+
+        self::assertContains('6 position cron', $consoleOutput[6]);
     }
 
     public function testListSchedulerCommand_withTasksAndCronStyle()

--- a/tests/Integration/MockConsoleKernel.php
+++ b/tests/Integration/MockConsoleKernel.php
@@ -11,5 +11,6 @@ class MockConsoleKernel extends \Orchestra\Testbench\Console\Kernel
         $schedule->command('test:command:name')->dailyAt('10:00')->description('Description of event');
         $schedule->command('test:command:two')->dailyAt('10:00')->timezone('UTC');
         $schedule->exec('ls -lah')->mondays()->at('3:00');
+        $schedule->exec('with 6 position cron')-> cron('* * * * * *');
     }
 }


### PR DESCRIPTION
Support Laravel 5.5 by truncating the long version of the cron expression used in Laravel 5.5 and below.
Also build and test with both PHP versions and Laravel versions in Travis