### PR TITLE
Remove command strings via config

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,26 @@ For occasions when you need to access the list of scheduled events programmatica
 Inject the `ScheduleList` or resolve it from the Container and then call `all()` to get all scheduled events.
 Usage of it can be seen in [ListScheduler::handle](src/Console/ListScheduler.php)
 
+## Define PHP Binary Path
+
+If you use custom PHP Binary paths or you are using `\Hmazter\LaravelScheduleList\ScheduleList::all` within the context of a web application and not through the console, you can publish the package config file and defining your own binary path:
+
+```
+php artisan vendor:publish --provider="Hmazter\LaravelScheduleList\ScheduleListServiceProvider" --tag="config"
+```
+
+For example `config/schedule-list.php`:
+```
+<?php
+
+return [
+    'remove_strings_from_command' => [
+        "'".PHP_BINARY."'",
+        "'artisan'",
+    ],
+];
+```
+
 ## Known limitations
 
 Laravel ships with some special scheduling functions ex `between`, `unlessBetween`, `when` and  `skip`

--- a/config/schedule-list.php
+++ b/config/schedule-list.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'remove_strings_from_command' => [
+        "'".PHP_BINARY."'",
+        "'artisan'",
+    ],
+];

--- a/src/ScheduleEvent.php
+++ b/src/ScheduleEvent.php
@@ -97,7 +97,13 @@ class ScheduleEvent
     {
         $command = $this->getFullCommand();
         $command = substr($command, 0, strpos($command, '>'));
-        $command = trim(str_replace(["'".PHP_BINARY."'", "'artisan'"], '', $command));
+        $command = trim(str_replace(
+            config('schedule-list.remove_strings_from_command', [
+                "'".PHP_BINARY."'",
+                "'artisan'",
+            ]), '', $command)
+        );
+
         return $command;
     }
 

--- a/src/ScheduleListServiceProvider.php
+++ b/src/ScheduleListServiceProvider.php
@@ -22,6 +22,13 @@ class ScheduleListServiceProvider extends ServiceProvider
      */
     protected $defer = false;
 
+    public function boot()
+    {
+        $this->publishes([
+            __DIR__ . '/../config/schedule-list.php' => config_path('schedule-list.php'),
+        ], 'config');
+    }
+
     /**
      * Register the service provider.
      *
@@ -29,6 +36,8 @@ class ScheduleListServiceProvider extends ServiceProvider
      */
     public function register()
     {
+        $this->mergeConfigFrom(__DIR__.'/../config/schedule-list.php', 'schedule-list');
+
         $this->commands([
             Console\ListScheduler::class
         ]);

--- a/tests/Function/ScheduleEventTest.php
+++ b/tests/Function/ScheduleEventTest.php
@@ -75,4 +75,24 @@ class ScheduleEventTest extends TestCase
         self::assertEquals('* * * * *', $scheduleEvent->getExpression());
         self::assertInstanceOf(Carbon::class, $scheduleEvent->getNextRunDate());
     }
+
+    /** @test */
+    public function getShortCommand_removesStringsProvidedThroughConfig()
+    {
+        config(['schedule-list.remove_strings_from_command' => [
+            "'/usr/bin/php'",
+            "'art'",
+        ]]);
+
+        $command = "'/usr/bin/php' 'art' test:hello --name=\"John Doe\" > /dev/null";
+
+        $scheduleEvent = new ScheduleEvent(
+            '',
+            null,
+            $command,
+            ''
+        );
+
+        self::assertEquals('test:hello --name="John Doe"', $scheduleEvent->getShortCommand());
+    }
 }


### PR DESCRIPTION
This change allows users to specify certain strings to remove from a scheduled Artisan command.

The use case for this I see is when using the `\Hmazter\LaravelScheduleList\ScheduleList::all` functionality to programatically retrieve the schedule, and display it via a web browser rather than the console.

Unfortunately, when I tried to do this, the `PHP_BINARY` constant is equal to `''`, which is used in the code itself to remove certain parts of the full command string.

This means all command descriptions are set to empty strings before this PR.

This change allows end users to specify their own overrides for this if they need to.

Thanks for a very useful package!