### PR TITLE
Handle scheduled Closures and Jobs

### DIFF
--- a/src/ScheduleEvent.php
+++ b/src/ScheduleEvent.php
@@ -112,7 +112,11 @@ class ScheduleEvent
      */
     public function getCommandName(): string
     {
-        list($commandName) = Parser::parse($this->getShortCommand());
+        $shortCommand = $this->getShortCommand();
+        if (empty($shortCommand)) {
+            return '';
+        }
+        list($commandName) = Parser::parse($shortCommand);
         return $commandName;
     }
 

--- a/src/ScheduleList.php
+++ b/src/ScheduleList.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Hmazter\LaravelScheduleList;
 
+use Illuminate\Console\Scheduling\CallbackEvent;
 use Illuminate\Console\Scheduling\Event;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
@@ -40,6 +41,10 @@ class ScheduleList
         foreach ($this->schedule->events() as $event) {
             $fullCommand = $event->buildCommand();
 
+            if ($event instanceof CallbackEvent) {
+                $fullCommand = 'Closure' . $fullCommand;
+            }
+
             $scheduleEvent = new ScheduleEvent(
                 $event->getExpression(),
                 $event->timezone,
@@ -47,7 +52,7 @@ class ScheduleList
                 $event->description ?? ''
             );
 
-            if (empty($scheduleEvent->getDescription())) {
+            if (empty($scheduleEvent->getDescription()) && $scheduleEvent->getCommandName()) {
                 $scheduleEvent->setDescription($this->getDescriptionFromCommand($scheduleEvent->getCommandName()));
             }
 

--- a/tests/Integration/ListSchedulerTest.php
+++ b/tests/Integration/ListSchedulerTest.php
@@ -30,20 +30,32 @@ class ListSchedulerTest extends TestCase
         self::assertContains('Description of test command', $consoleOutput[4]);
 
         self::assertContains('ls -lah', $consoleOutput[5]);
+
+        self::assertContains('0 13 * * *', $consoleOutput[6]);
+        self::assertContains('Closure', $consoleOutput[6]);
+        self::assertContains('A description for a scheduled callback', $consoleOutput[6]);
+
+        self::assertContains('0 14 * * *', $consoleOutput[7]);
+        self::assertContains('Closure', $consoleOutput[7]);
+        self::assertContains('TestJob', $consoleOutput[7]);
     }
 
     public function testListSchedulerCommand_withTasksAndCronStyle()
     {
         \Illuminate\Support\Facades\Artisan::call('schedule:list', ['--cron' => true]);
-        $consoleOutput = trim(\Illuminate\Support\Facades\Artisan::output());
+        $consoleOutput = explode("\n", trim(\Illuminate\Support\Facades\Artisan::output()));
 
-        self::assertContains('test:command:name', $consoleOutput);
-        self::assertContains('artisan', $consoleOutput);
-        self::assertContains('0 10 * * *', $consoleOutput);
-        self::assertContains((DIRECTORY_SEPARATOR === '\\') ? 'NUL' : '/dev/null', $consoleOutput);
+        self::assertContains('test:command:name', $consoleOutput[0]);
+        self::assertContains('artisan', $consoleOutput[0]);
+        self::assertContains('0 10 * * *', $consoleOutput[0]);
+        self::assertContains((DIRECTORY_SEPARATOR === '\\') ? 'NUL' : '/dev/null', $consoleOutput[0]);
 
-        self::assertContains('test:command:two', $consoleOutput);
+        self::assertContains('test:command:two', $consoleOutput[1]);
 
-        self::assertContains('ls -lah', $consoleOutput);
+        self::assertContains('ls -lah', $consoleOutput[2]);
+
+        self::assertContains('Closure', $consoleOutput[3]);
+
+        self::assertContains('Closure', $consoleOutput[4]);
     }
 }

--- a/tests/Integration/MockConsoleKernel.php
+++ b/tests/Integration/MockConsoleKernel.php
@@ -8,8 +8,14 @@ class MockConsoleKernel extends \Orchestra\Testbench\Console\Kernel
 
     protected function schedule(\Illuminate\Console\Scheduling\Schedule $schedule)
     {
+        $closure = function () {
+            echo 'callback or invokable class';
+        };
+
         $schedule->command('test:command:name')->dailyAt('10:00')->description('Description of event');
         $schedule->command('test:command:two')->dailyAt('10:00')->timezone('UTC');
         $schedule->exec('ls -lah')->mondays()->at('3:00');
+        $schedule->call($closure)->dailyAt('13:00')->description('A description for a scheduled callback');
+        $schedule->job(new \TestJob())->dailyAt('14:00');
     }
 }

--- a/tests/Integration/TestJob.php
+++ b/tests/Integration/TestJob.php
@@ -1,0 +1,6 @@
+<?php
+
+class TestJob
+{
+    //
+}


### PR DESCRIPTION
Fixes #23 by showing "Closure" as the command for scheduled Closures and Jobs

This would be the output:
```
+------------+---------------------+-------------------+----------------------------------------+
| expression | next run at         | command           | description                            |
+------------+---------------------+-------------------+----------------------------------------+
| 0 10 * * * | 2018-09-23 10:00:00 | test:command:name | Description of event                   |
| 0 10 * * * | 2018-09-23 10:00:00 | test:command:two  | Description of test command            |
| 0 3 * * 1  | 2018-09-24 03:00:00 | ls -lah           |                                        |
| 0 13 * * * | 2018-09-23 13:00:00 | Closure           | A description for a scheduled callback |
| 0 14 * * * | 2018-09-23 14:00:00 | Closure           | TestJob                                |
+------------+---------------------+-------------------+----------------------------------------+
```