### PR TITLE
Add column in console output showing withoutOverlapping-locks, closes #8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Column showing status for "without overlapping"-locks
+
+### Changed
+- \Hmazter\LaravelScheduleList\ScheduleList::all now returns a Collection instead of array
+
 ## [1.1.1] - 2018-09-23
 ### Fixed
 - Fixed crash when scheduling Closures and Jobs, #23 

--- a/src/Console/ListScheduler.php
+++ b/src/Console/ListScheduler.php
@@ -6,6 +6,7 @@ namespace Hmazter\LaravelScheduleList\Console;
 use Hmazter\LaravelScheduleList\ScheduleEvent;
 use Hmazter\LaravelScheduleList\ScheduleList;
 use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -59,7 +60,7 @@ class ListScheduler extends Command
     {
         $events = $this->scheduleList->all();
 
-        if (count($events) === 0) {
+        if ($events->isEmpty()) {
             $this->info('No tasks scheduled');
             return;
         }
@@ -73,9 +74,9 @@ class ListScheduler extends Command
     }
 
     /**
-     * @param array|ScheduleEvent[] $events
+     * @param Collection|ScheduleEvent[] $events
      */
-    protected function outputCronStyle($events)
+    protected function outputCronStyle(Collection $events)
     {
         foreach ($events as $event) {
             $this->line($event->getExpression() . ' ' . $event->getFullCommand());
@@ -83,19 +84,27 @@ class ListScheduler extends Command
     }
 
     /**
-     * @param array|ScheduleEvent[] $events
+     * @param Collection|ScheduleEvent[] $events
      */
     protected function outputTableStyle($events)
     {
         $isVerbosityNormal = $this->output->getVerbosity() === OutputInterface::VERBOSITY_NORMAL;
+        $usesMutexLocks = $events->reduce(function (bool $carry, ScheduleEvent $event) {
+            return $carry || $event->getMutexStatus() !== null;
+        }, false);
+
         $rows = [];
         foreach ($events as $event) {
-            $rows[] = [
+            $row = [
                 'expression' => $event->getExpression(),
                 'next run at' => $event->getNextRunDate()->format('Y-m-d H:i:s'),
                 'command' => $isVerbosityNormal ? $event->getShortCommand() : $event->getFullCommand(),
                 'description' => $event->getDescription(),
             ];
+            if ($usesMutexLocks) {
+                $row['overlapping lock'] = $event->getOverlappingLockDescription();
+            }
+            $rows[] = $row;
         }
 
         $headers = array_keys($rows[0]);

--- a/tests/Integration/ListSchedulerTest.php
+++ b/tests/Integration/ListSchedulerTest.php
@@ -17,7 +17,8 @@ class ListSchedulerTest extends TestCase
     public function testListSchedulerCommand_withTasksAndTableStyle()
     {
         \Illuminate\Support\Facades\Artisan::call('schedule:list');
-        $consoleOutput = explode("\n", trim(\Illuminate\Support\Facades\Artisan::output()));
+        $consoleOutput = trim(\Illuminate\Support\Facades\Artisan::output());
+        $consoleOutput = explode("\n", $consoleOutput);
         $cron = \Cron\CronExpression::factory('0 10 * * *');
 
         self::assertContains('test:command:name', $consoleOutput[3]);
@@ -38,12 +39,18 @@ class ListSchedulerTest extends TestCase
         self::assertContains('0 14 * * *', $consoleOutput[7]);
         self::assertContains('Closure', $consoleOutput[7]);
         self::assertContains('TestJob', $consoleOutput[7]);
+
+        self::assertContains('Not locked', $consoleOutput[8]);
+
+        self::assertContains('Locked', $consoleOutput[9]);
+        self::assertNotContains('Not locked', $consoleOutput[9]);
     }
 
     public function testListSchedulerCommand_withTasksAndCronStyle()
     {
         \Illuminate\Support\Facades\Artisan::call('schedule:list', ['--cron' => true]);
-        $consoleOutput = explode("\n", trim(\Illuminate\Support\Facades\Artisan::output()));
+        $consoleOutput = trim(\Illuminate\Support\Facades\Artisan::output());
+        $consoleOutput = explode("\n", $consoleOutput);
 
         self::assertContains('test:command:name', $consoleOutput[0]);
         self::assertContains('artisan', $consoleOutput[0]);

--- a/tests/Integration/MockConsoleKernel.php
+++ b/tests/Integration/MockConsoleKernel.php
@@ -17,5 +17,8 @@ class MockConsoleKernel extends \Orchestra\Testbench\Console\Kernel
         $schedule->exec('ls -lah')->mondays()->at('3:00');
         $schedule->call($closure)->dailyAt('13:00')->description('A description for a scheduled callback');
         $schedule->job(new \TestJob())->dailyAt('14:00');
+        $schedule->exec('ls')->daily()->withoutOverlapping();
+        $event = $schedule->exec('cd')->daily()->withoutOverlapping();
+        $event->mutex->create($event);
     }
 }


### PR DESCRIPTION
This PR adds a column in the console output that shows the status of overlapping lock. The column is only shown if at least one scheduled item uses `withoutOverlapping()`

Output:
```
+------------+---------------------+-------------------+----------------------------------------+------------------+
| expression | next run at         | command           | description                            | overlapping lock |
+------------+---------------------+-------------------+----------------------------------------+------------------+
| 0 10 * * * | 2018-09-24 10:00:00 | test:command:name | Description of event                   | N/A              |
| 0 10 * * * | 2018-09-24 10:00:00 | test:command:two  | Description of test command            | N/A              |
| 0 3 * * 1  | 2018-10-01 03:00:00 | ls -lah           |                                        | N/A              |
| 0 13 * * * | 2018-09-24 13:00:00 | Closure           | A description for a scheduled callback | N/A              |
| 0 14 * * * | 2018-09-24 14:00:00 | Closure           | TestJob                                | N/A              |
| 0 0 * * *  | 2018-09-25 00:00:00 | ls                |                                        | Not locked       |
| 0 0 * * *  | 2018-09-25 00:00:00 | cd                |                                        | Locked           |
+------------+---------------------+-------------------+----------------------------------------+------------------+
```