### PR TITLE
Resolve the Schedule class from the container instead of DI, fixes #30

### DIFF
--- a/src/ScheduleList.php
+++ b/src/ScheduleList.php
@@ -11,22 +11,15 @@ use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
 class ScheduleList
 {
     /**
-     * @var Schedule
-     */
-    private $schedule;
-
-    /**
      * @var ConsoleKernel
      */
     private $consoleKernel;
 
     /**
-     * @param Schedule $schedule
      * @param ConsoleKernel $consoleKernel
      */
-    public function __construct(Schedule $schedule, ConsoleKernel $consoleKernel)
+    public function __construct(ConsoleKernel $consoleKernel)
     {
-        $this->schedule = $schedule;
         $this->consoleKernel = $consoleKernel;
     }
 
@@ -38,7 +31,7 @@ class ScheduleList
         $events = [];
 
         /** @var Event $event */
-        foreach ($this->schedule->events() as $event) {
+        foreach (app(Schedule::class)->events() as $event) {
             $fullCommand = $event->buildCommand();
 
             if ($event instanceof CallbackEvent) {


### PR DESCRIPTION
The Schedule class is resolved from the Container with the global app() function when needed in the
ScheduleList::all method instead of Dependecy injection in the construction.
This is to make sure that Laravel has resolved the class itself and filled in with all schduled tasks
and we get the same instance.