### PR TITLE
Add support for PHP 8.0

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       #fail-fast: true
       matrix:
-        php: [7.2, 7.3, 7.4]
+        php: [7.2, 7.3, 7.4, 8.0]
         laravel: [5.6.*, 5.7.*, 5.8.*, 6.*, 7.*, 8.*]
         include:
           - laravel: 5.6.*

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,6 +23,10 @@ jobs:
             phpunit: 8.*
           - laravel: 6.*
             testbench: 4.*
+            phpunit: 8.*
+          - laravel: 6.*
+            php: 8.0
+            testbench: 4.*
             phpunit: 9.*
           - laravel: 7.*
             testbench: 5.*

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,13 +23,13 @@ jobs:
             phpunit: 8.*
           - laravel: 6.*
             testbench: 4.*
-            phpunit: 8.*
+            phpunit: 9.*
           - laravel: 7.*
             testbench: 5.*
-            phpunit: 8.*
+            phpunit: 9.*
           - laravel: 8.*
             testbench: 6.*
-            phpunit: 8.*
+            phpunit: 9.*
         exclude:
           # Laravel 8.* does not support PHP 7.2
           - laravel: 8.*

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -74,7 +74,7 @@ jobs:
         run: |
           composer require "illuminate/support:${{ matrix.laravel }}" "illuminate/console:${{ matrix.laravel }}"  --no-interaction --no-update
           composer require --dev "orchestra/testbench:${{ matrix.testbench }}" "phpunit/phpunit:${{ matrix.phpunit }}" --no-interaction --no-update
-          composer install --prefer-dist --no-interaction --no-suggest
+          composer install --prefer-dist --no-interaction
 
       - name: Execute tests
         run: vendor/bin/phpunit

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -64,6 +64,7 @@ jobs:
           php-version: ${{ matrix.php }}
           extensions: libxml, mbstring, bcmath
           coverage: none
+          tools: composer:v2
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -34,6 +34,13 @@ jobs:
           # Laravel 8.* does not support PHP 7.2
           - laravel: 8.*
             php: 7.2
+          # Laravel < 6 does not support PHP 8
+          - laravel: 5.6.*
+            php: 8.0
+          - laravel: 5.7.*
+            php: 8.0
+          - laravel: 5.8.*
+            php: 8.0
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -30,6 +30,10 @@ jobs:
             phpunit: 9.*
           - laravel: 7.*
             testbench: 5.*
+            phpunit: 8.*
+          - laravel: 7.*
+            php: 8.0
+            testbench: 5.*
             phpunit: 9.*
           - laravel: 8.*
             testbench: 6.*

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -56,12 +56,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v1
 
-      - name: Cache dependencies
-        uses: actions/cache@v1
-        with:
-          path: ~/.composer/cache/files
-          key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
-
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -69,6 +63,16 @@ jobs:
           extensions: libxml, mbstring, bcmath
           coverage: none
           tools: composer:v2
+
+      - name: Get composer cache directory
+        id: composercache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Cache dependencies
+        uses: actions/cache@v1
+        with:
+          path: ${{ steps.composercache.outputs.dir }}
+          key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
 
       - name: Install dependencies
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased] - 
+### Other
+- Support PHP 8.0
 
 ## [2.2.0] - 2020-09-04
 ### Other

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     }
   ],
   "require": {
-    "php": "^7.2",
+    "php": "^7.2|^8.0",
     "illuminate/support": "5.6.*|5.7.*|5.8.*|^6.0|^7.0|^8.0",
     "illuminate/console": "5.6.*|5.7.*|5.8.*|^6.0|^7.0|^8.0",
     "dragonmantank/cron-expression": "^2.0|^3.0"

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
     "dragonmantank/cron-expression": "^2.0|^3.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^8.3",
-    "orchestra/testbench": "~3.6"
+    "phpunit/phpunit": "^9.3",
+    "orchestra/testbench": "6.*"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
* Allow PHP 8.0 in composer.json
* Run tests against PHP 8.0

Also:
* Use composer v2 in GitHub actions
* Remove deprecated use of --no-suggest flag to composer v2
* Fix composer cache path