### PR TITLE
Remove support for Laravel 8.19.0 and above

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,7 @@ jobs:
       #fail-fast: true
       matrix:
         php: [7.2, 7.3, 7.4, 8.0]
-        laravel: [5.6.*, 5.7.*, 5.8.*, 6.*, 7.*, 8.*]
+        laravel: [5.6.*, 5.7.*, 5.8.*, 6.*, 7.*, 8.18.1]
         include:
           - laravel: 5.6.*
             testbench: 3.6
@@ -35,12 +35,12 @@ jobs:
             php: 8.0
             testbench: 5.*
             phpunit: 9.*
-          - laravel: 8.*
+          - laravel: 8.18.1
             testbench: 6.*
             phpunit: 9.*
         exclude:
           # Laravel 8.* does not support PHP 7.2
-          - laravel: 8.*
+          - laravel: 8.18.1
             php: 7.2
           # Laravel < 6 does not support PHP 8
           - laravel: 5.6.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased] - 
+### Other
+- Not compatible with Laravel 8.19.0 (and above)
 
 ## [2.2.1] - 2020-12-02 
 ### Other

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
   ],
   "require": {
     "php": "^7.2|^8.0",
-    "illuminate/support": "5.6.*|5.7.*|5.8.*|^6.0|^7.0|^8.0",
-    "illuminate/console": "5.6.*|5.7.*|5.8.*|^6.0|^7.0|^8.0",
+    "illuminate/support": ">= 5.6 < 8.19",
+    "illuminate/console": ">= 5.6 < 8.19",
     "dragonmantank/cron-expression": "^2.0|^3.0"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -11,13 +11,17 @@
   ],
   "require": {
     "php": "^7.2|^8.0",
-    "illuminate/support": ">= 5.6 < 8.19",
-    "illuminate/console": ">= 5.6 < 8.19",
+    "illuminate/support": "5.6.*|5.7.*|5.8.*|^6.0|^7.0|^8.0",
+    "illuminate/console": "5.6.*|5.7.*|5.8.*|^6.0|^7.0|^8.0",
     "dragonmantank/cron-expression": "^2.0|^3.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.3",
     "orchestra/testbench": "6.*"
+  },
+  "conflict": {
+    "illuminate/support": "^8.19",
+    "illuminate/console": "^8.19"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Update the constraints for illuminate/support and illuminate/console to not be compatible with Laravel 8.19.0 since that version include its own `schedule:list` command.